### PR TITLE
fix: non-consecutive config scripts

### DIFF
--- a/starship/scripts/install.sh
+++ b/starship/scripts/install.sh
@@ -63,7 +63,7 @@ function set_helm_args() {
     chain=$(yq -r ".chains[$i].id" ${CONFIGFILE})
     scripts=$(yq -r ".chains[$i].scripts" ${CONFIGFILE})
     if [[ "$scripts" == "null" ]]; then
-      return 0
+      continue
     fi
     datadir="$(cd "$(dirname -- "${CONFIGFILE}")" >/dev/null; pwd -P)"
     for script in $(yq -r ".chains[$i].scripts | keys | .[]" ${CONFIGFILE}); do


### PR DESCRIPTION
When a chain config a `scripts` property after another that did not, it would omit the arg, resulting in a validation error installing the config.

This makes it iterate over all the chains to get the correct arguments.