### PR TITLE
feat: add and use `chain.scripts.chainRpcReady`

### DIFF
--- a/docs/config/chains.mdx
+++ b/docs/config/chains.mdx
@@ -242,6 +242,7 @@ Types of scripts that are allowed inside the `scripts` dir are:
 * `createValidator`: Script to run the `create-validator` txn on the validator nodes after spinup. Note this script is run as part of the `PostStartHook` of the validator pods. Default: [`create-validator.sh`](https://github.com/hyperweb-io/starship/blob/main/starship/charts/devnet/scripts/default/create-validator.sh)
 * `transferTokens`: Script run as part of the Starship glue code. This script is related to the faucet that we run. Default: [`transfer-tokens.sh`](https://github.com/hyperweb-io/starship/blob/main/charts/starship/devnet/scripts/default/transfer-tokens.sh)
 * `buildChain`: Script that builds chain binaries, based on the `build` directive. Default: [`build-chain.sh`](https://github.com/hyperweb-io/starship/blob/main/starship/charts/devnet/scripts/default/build-chain.sh)
+* `chainRpcReady`: Script that checks if the chain is ready to accept RPC calls. Default: [`chain-rpc-ready.sh`](https://github.com/hyperweb-io/starship/blob/main/starship/charts/devnet/scripts/default/chain-rpc-ready.sh)
 
 One can choose the sub-scripts that need to be overwritten, default scripts will be used instead.
 

--- a/starship/charts/devnet/defaults.yaml
+++ b/starship/charts/devnet/defaults.yaml
@@ -673,25 +673,6 @@ defaultChains:
             exponent: 6
         coingecko_id: inter-stable-token
         keywords: [ "inter-stable-token" ]
-    readinessProbe:
-      exec:
-        command:
-          - bash
-          - -c
-          - |
-            # Try to see if the node is still catching up.
-            ([[ $($CHAIN_BIN status 2>&1 | jq -r .SyncInfo.catching_up) == false ]]) &
-            tester=$!
-            # Kill the test if it takes longer than we expect.
-            (sleep 5; kill $tester 2>/dev/null) &
-            killer=$!
-            # Kill the killer before exiting.
-            trap 'kill $killer 2>/dev/null' EXIT
-            # Return the test's exit code, whether it succeeded, failed, or was killed.
-            wait $tester
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      timeoutSeconds: 15
   kujira:
     image: ghcr.io/cosmology-tech/starship/kujira:v1.1.0
     home: /root/.kujira
@@ -1010,6 +991,9 @@ defaultScripts:
   buildChain:
     name: build-chain.sh
     file: scripts/default/build-chain.sh
+  chainRpcReady:
+    name: chain-rpc-ready.sh
+    file: scripts/default/chain-rpc-ready.sh
   ibcConnection:
     name: ibc-connection.sh
     file: scripts/default/ibc-connection.sh

--- a/starship/charts/devnet/scripts/default/chain-rpc-ready.sh
+++ b/starship/charts/devnet/scripts/default/chain-rpc-ready.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# chain-rpc-ready.sh - Check if a CometBFT or Tendermint RPC service is ready
+# Usage: chain-rpc-ready.sh [RPC_URL]
+
+set -euo pipefail
+
+RPC_URL=${1:-"http://localhost:26657"}
+
+echo 1>&2 "Checking if $RPC_URL is ready..."
+
+# Check if the RPC URL is reachable,
+json=$(curl -s --connect-timeout 2 "$RPC_URL/status")
+
+# and the bootstrap block state has been validated,
+if [ "$(echo "$json" | jq -r '.result.sync_info | (.earliest_block_height < .latest_block_height)')" != true ]; then
+  echo 1>&2 "$RPC_URL is not ready: bootstrap block state has not been validated"
+  exit 1
+fi
+
+# and the node is not catching up.
+if [ "$(echo "$json" | jq -r .result.sync_info.catching_up)" != false ]; then
+  echo 1>&2 "$RPC_URL is not ready: node is catching up"
+  exit 1
+fi
+
+echo "$json" | jq -r .result
+exit 0

--- a/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -284,9 +284,12 @@ spec:
             {{- if hasKey $chain "readinessProbe" }}
             {{- $chain.readinessProbe | toYaml | nindent 12 }}
             {{- else }}
-            httpGet:
-              path: /status
-              port: 26657
+            exec:
+              command:
+                - bash
+                - -e
+                - /scripts/chain-rpc-ready.sh
+                - http://localhost:26657
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 15
@@ -377,18 +380,16 @@ spec:
 
               export | grep "FAUCET"
 
-              while [ $(curl -sw '%{http_code}' http://localhost:26657/status -o /dev/null) -ne 200 ]; do
-                echo "Validator node does not seem to be ready. Waiting for it to start..."
-                echo "Checking: http://localhost:26657/status"
+              until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
                 sleep 10;
               done
-
-              curl http://localhost:26657/status
 
               /app/packages/faucet/bin/cosmos-faucet-dist start "http://localhost:26657"
           volumeMounts:
             - mountPath: /configs
               name: addresses
+            - mountPath: /scripts
+              name: scripts
           resources: {{- include "getResourceObject" $chain.faucet.resources | trim | nindent 12 }}
           readinessProbe:
             httpGet:
@@ -444,12 +445,9 @@ spec:
 
               export | grep "FAUCET"
 
-              until [[ $(curl -s --connect-timeout 2 http://localhost:26657/status | jq -r '.result.sync_info.latest_block_height // "0"' | grep -E '^[1-9][0-9]*$') ]]; do
-                echo "Validator node not ready or block height is still 0. Retrying in 5s..."
-                sleep 5
+              until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
+                sleep 10
               done
-
-              curl http://localhost:26657/status
 
               /faucet/faucet --credit-coins="$CREDIT_COINS" --chain-fees="$FEES"
           volumeMounts:
@@ -457,6 +455,8 @@ spec:
               name: addresses
             - mountPath: /faucet
               name: faucet
+            - mountPath: /scripts
+              name: scripts
           resources: {{- include "getResourceObject" $chain.faucet.resources | trim | nindent 12 }}
           readinessProbe:
             httpGet:

--- a/starship/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -253,10 +253,8 @@ spec:
                   - "-c"
                   - "-e"
                   - |
-                    while [ $(curl -sw '%{http_code}' http://localhost:26657/status -o /dev/null) -ne 200 ]; do
-                      echo "Validator node does not seem to be ready. Waiting for it to start..."
-                      echo "Checking: http://localhost:26657/status"
-                      sleep 10;
+                    until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
+                      sleep 10
                     done
 
                     set -eux
@@ -289,9 +287,12 @@ spec:
             {{- if hasKey $chain "readinessProbe" }}
             {{- $chain.readinessProbe | toYaml | nindent 12 }}
             {{- else }}
-            httpGet:
-              path: /status
-              port: 26657
+            exec:
+              command:
+                - bash
+                - -e
+                - /scripts/chain-rpc-ready.sh
+                - http://localhost:26657
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 15

--- a/starship/charts/devnet/values.schema.json
+++ b/starship/charts/devnet/values.schema.json
@@ -477,6 +477,22 @@
                   "data"
                 ]
               },
+              "chainRpcReady": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "file",
+                  "data"
+                ]
+              },
               "ibcConnection": {
                 "type": "object",
                 "properties": {

--- a/starship/charts/devnet/values.yaml
+++ b/starship/charts/devnet/values.yaml
@@ -146,6 +146,10 @@ chains: []
   #     buildChain:
   #       file: local/scripts/build-chain.sh
   #       data: |- # data is a multiline string injected from --set-file in helm
+  #     ## chainRpcReady script that checks if RPC services are ready
+  #     chainRpcReady:
+  #       file: local/scripts/chain-rpc-ready.sh
+  #       data: |- # data is a multiline string injected from --set-file in helm
   #   # set custom environment variables for the `validator` container
   #   env:
   #     - name: DEBUG


### PR DESCRIPTION
This PR consolidates all the different ways of checking if a chain node's RPC service is ready to use.

Documentation, scripts, and examples have been updated accordingly.

The Agoric `readinessProbe` now just uses the defaults.  I've verified that properly waiting for RPC to become ready (instead of restarting the pod's faucet and hitting backoff) has reduced the time needed to boot up `agoriclocal-genesis-0` on my machine from 14 minutes down to 6 minutes.
