### PR TITLE
feat(cosmos): propagate `$chain.env` when calling scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "starship/exposer/**"
       - "starship/registry/**"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "starship/docker/**"
       - ".github/workflows/docker.yaml"

--- a/.github/workflows/lint-check.yaml
+++ b/.github/workflows/lint-check.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "starship/charts/**"
       - ".github/workflows/lint-check.yaml"

--- a/.github/workflows/lint-client.yml
+++ b/.github/workflows/lint-client.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "clients/js/**"
       - ".github/workflows/lint-client.yml"

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
       - release/*
     paths:
       - "starship/**"

--- a/.github/workflows/run-client-tests.yml
+++ b/.github/workflows/run-client-tests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "clients/js/**"
       - ".github/workflows/run-client-tests.yml"

--- a/.github/workflows/starship-docker.yaml
+++ b/.github/workflows/starship-docker.yaml
@@ -13,6 +13,7 @@ on:
   pull_request:
     branches:
       - main
+      - v1
     paths:
       - "starship/registry/**"
       - "starship/exposer/**"

--- a/starship/charts/devnet/Chart.yaml
+++ b/starship/charts/devnet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/starship/charts/devnet/templates/_helpers.tpl
+++ b/starship/charts/devnet/templates/_helpers.tpl
@@ -83,6 +83,10 @@ Environment variables for chain from configmaps
 {{- define "devnet.evnVars" }}
 - name: CHAIN_ID
   value: {{ .id }}
+{{- range $env := .env }}
+- name: {{ $env.name }}
+  value: {{ $env.value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/genesis.yaml
@@ -54,6 +54,8 @@ spec:
               UPGRADE_NAME=genesis CODE_TAG={{ $chain.build.source }} bash -e /scripts/build-chain.sh
               {{- end }}
           env:
+            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{ include "devnet.evnVars" $chain | indent 12 }}
             - name: CODE_REF
               value: {{ $chain.repo }}
             - name: UPGRADE_DIR
@@ -62,7 +64,6 @@ spec:
               value: /go/bin
             - name: CHAIN_NAME
               value: {{ $chain.id }}
-            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
           resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
           volumeMounts:
             - mountPath: {{ $chain.home }}
@@ -253,10 +254,6 @@ spec:
               value: "{{ $chain.faucet.enabled }}"
             - name: SLOGFILE
               value: "slog.slog"
-            {{- range $env := $chain.env }}
-            - name: {{ $env.name }}
-              value: {{ $env.value | quote }}
-            {{- end }}
           command:
             - bash
             - "-c"
@@ -299,6 +296,8 @@ spec:
           image: {{ $.Values.exposer.image }}
           imagePullPolicy: {{ $.Values.images.imagePullPolicy }}
           env:
+            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{ include "devnet.evnVars" $chain | indent 12 }}
             {{- include "devnet.genesisVars" $dataExposer | indent 12}}
             - name: EXPOSER_HTTP_PORT
               value: "8081"
@@ -329,6 +328,8 @@ spec:
           image: {{ $chain.faucet.image }}
           imagePullPolicy: {{ $.Values.images.imagePullPolicy }}
           env:
+            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{ include "devnet.evnVars" $chain | indent 12 }}
             - name: FAUCET_CONCURRENCY
               value: "{{ $chain.faucet.concurrency }}"
             - name: FAUCET_PORT
@@ -402,6 +403,8 @@ spec:
           image: {{ $chain.image }}
           imagePullPolicy: {{ $.Values.images.imagePullPolicy }}
           env:
+            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{ include "devnet.evnVars" $chain | indent 12 }}
             - name: FAUCET_CONCURRENCY
               value: "{{ $chain.faucet.concurrency }}"
             - name: FAUCET_HTTP_PORT

--- a/starship/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -57,6 +57,8 @@ spec:
               UPGRADE_NAME=genesis CODE_TAG={{ $chain.build.source }} bash -e /scripts/build-chain.sh
               {{- end }}
           env:
+            {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
+            {{ include "devnet.evnVars" $chain | indent 12 }}
             - name: CODE_REF
               value: {{ $chain.repo }}
             - name: UPGRADE_DIR
@@ -65,7 +67,6 @@ spec:
               value: /go/bin
             - name: CHAIN_NAME
               value: {{ $chain.id }}
-                    {{ include "devnet.defaultEvnVars" $chain | indent 12 }}
           resources: {{- include "devnet.node.resources" ( dict "node" $chain "context" $ ) | trim | nindent 12 }}
           volumeMounts:
             - mountPath: {{ $chain.home }}
@@ -153,6 +154,7 @@ spec:
               bash -e /scripts/update-config.sh
               
               curl -s http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/node_id
+              echo
               NODE_ID=$(curl -s http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:$GENESIS_PORT/node_id | jq -r ".node_id")
               if [[ $NODE_ID == "" ]]; then
                 echo "Node ID is null, exiting early"
@@ -222,10 +224,6 @@ spec:
               value: /configs/keys.json
             - name: SLOGFILE
               value: "slog.slog"
-            {{- range $env := $chain.env }}
-            - name: {{ $env.name }}
-              value: {{ $env.value | quote }}
-            {{- end }}
           command:
             - bash
             - "-c"
@@ -253,15 +251,16 @@ spec:
                   - "-c"
                   - "-e"
                   - |
-                    until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
-                      sleep 10
-                    done
-
                     set -eux
                     export
                     VAL_INDEX=${HOSTNAME##*-}
                     VAL_NAME="$(jq -r ".validators[0].name" $KEYS_CONFIG)-$VAL_INDEX"
                     echo "Validator Index: $VAL_INDEX, Key name: $VAL_NAME. Chain bin $CHAIN_BIN"
+
+                    echo "Waiting for RPC on http://$genesis_host:26657 to be ready..."
+                    until bash -e /scripts/chain-rpc-ready.sh http://$genesis_host:26657; do
+                      sleep 10
+                    done
 
                     VAL_ADDR=$($CHAIN_BIN keys show $VAL_NAME -a --keyring-backend="test")
                     echo "Transfer tokens to address $VAL_ADDR before trying to create validator. Best effort"

--- a/starship/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -257,8 +257,7 @@ spec:
                     VAL_NAME="$(jq -r ".validators[0].name" $KEYS_CONFIG)-$VAL_INDEX"
                     echo "Validator Index: $VAL_INDEX, Key name: $VAL_NAME. Chain bin $CHAIN_BIN"
 
-                    echo "Waiting for RPC on http://$genesis_host:26657 to be ready..."
-                    until bash -e /scripts/chain-rpc-ready.sh http://$genesis_host:26657; do
+                    until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
                       sleep 10
                     done
 

--- a/starship/charts/devnet/templates/chains/cosmos/validator.yaml
+++ b/starship/charts/devnet/templates/chains/cosmos/validator.yaml
@@ -257,7 +257,9 @@ spec:
                     VAL_NAME="$(jq -r ".validators[0].name" $KEYS_CONFIG)-$VAL_INDEX"
                     echo "Validator Index: $VAL_INDEX, Key name: $VAL_NAME. Chain bin $CHAIN_BIN"
 
-                    until bash -e /scripts/chain-rpc-ready.sh http://localhost:26657; do
+                    genesis_host="$GENESIS_HOST.$NAMESPACE.svc.cluster.local"
+                    echo "Waiting for RPC on http://$genesis_host:26657 to be ready..."
+                    until bash -e /scripts/chain-rpc-ready.sh http://$genesis_host:26657; do
                       sleep 10
                     done
 
@@ -266,7 +268,7 @@ spec:
                     bash -e /scripts/transfer-tokens.sh \
                       $VAL_ADDR \
                       $DENOM \
-                      http://$GENESIS_HOST.$NAMESPACE.svc.cluster.local:8000/credit \
+                      http://$genesis_host:8000/credit \
                       "{{ $chain.faucet.enabled }}" || true
 
                     $CHAIN_BIN keys list --keyring-backend test | jq


### PR DESCRIPTION
This PR allows parameterisation of a `config.yaml`'s 'chain[*].scripts', by passing `chain[*].env` environment variables wherever those scripts are invoked.  This apparently already worked for `$CHAIN_ID`, but not for any other of the config.yaml's environment variables.  There may be an even simpler way to accomplish it, so I am happy for any feedback you can suggest, @Anmol1696.

Before this change, some scripts that we override (`update-config.sh` for our particular use in [Agoric/agoric-sdk#11502](https://github.com/Agoric/agoric-sdk/pull/11502#issuecomment-2991200809)) would have to be manually copied-and-pasted with modifications, or generated from a template in order to have different behaviour when used in different `config.yaml` files but also with the same `$CHAIN_ID`.

Credit to @Muneeb147 for intuitively attempting to use `chain.env` for this purpose, and being (rightfully!) surprised that it wasn't applied when running our custom `update-config.sh`.